### PR TITLE
Fix rbegin() and rend() and provide tests for them

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -992,7 +992,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatConstIterator_<_Tp>> Mat::rbegin() const
 {
     if (empty())
-        return MatConstIterator_<_Tp>();
+        return std::reverse_iterator<MatConstIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     MatConstIterator_<_Tp> it((const Mat_<_Tp>*)this);
     it += total();
@@ -1014,7 +1014,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatConstIterator_<_Tp>> Mat::rend() const
 {
     if (empty())
-        return MatConstIterator_<_Tp>();
+        return std::reverse_iterator<MatConstIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     return std::reverse_iterator<MatConstIterator_<_Tp>>((const Mat_<_Tp>*)this);
 }
@@ -1032,7 +1032,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatIterator_<_Tp>> Mat::rbegin()
 {
     if (empty())
-        return MatIterator_<_Tp>();
+        return std::reverse_iterator<MatIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     MatIterator_<_Tp> it((Mat_<_Tp>*)this);
     it += total();
@@ -1055,7 +1055,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatIterator_<_Tp>> Mat::rend()
 {
     if (empty())
-        return MatIterator_<_Tp>();
+        return std::reverse_iterator<MatIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     return std::reverse_iterator<MatIterator_<_Tp>>(MatIterator_<_Tp>((Mat_<_Tp>*)this));
 }

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2355,4 +2355,49 @@ TEST(Mat, regression_18473)
 }
 
 
+TEST(Mat, reverse_iterator_19967)
+{
+    // empty iterator (#16855)
+    cv::Mat m_empty;
+    EXPECT_NO_THROW(m_empty.rbegin<uchar>());
+    EXPECT_NO_THROW(m_empty.rend<uchar>());
+    EXPECT_TRUE(m_empty.rbegin<uchar>() == m_empty.rend<uchar>());
+
+    // 1D test
+    std::vector<uchar> data{0, 1, 2, 3};
+    const std::vector<int> sizes_1d{4};
+    cv::Mat m_1d(sizes_1d, CV_8U, data.data());
+
+    auto mismatch_it_pair_1d = std::mismatch(data.rbegin(), data.rend(), m_1d.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_1d.first, data.rend());  // expect no mismatch
+    EXPECT_EQ(mismatch_it_pair_1d.second, m_1d.rend<uchar>());
+
+    // 2D test
+    const std::vector<int> sizes_2d{2, 2};
+    cv::Mat m_2d(sizes_2d, CV_8U, data.data());
+
+    auto mismatch_it_pair_2d = std::mismatch(data.rbegin(), data.rend(), m_2d.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_2d.first, data.rend());
+    EXPECT_EQ(mismatch_it_pair_2d.second, m_2d.rend<uchar>());
+
+    // 3D test
+    std::vector<uchar> data_3d{0, 1, 2, 3, 4, 5, 6, 7};
+    const std::vector<int> sizes_3d{2, 2, 2};
+    cv::Mat m_3d(sizes_3d, CV_8U, data_3d.data());
+
+    auto mismatch_it_pair_3d = std::mismatch(data_3d.rbegin(), data_3d.rend(), m_3d.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_3d.first, data_3d.rend());
+    EXPECT_EQ(mismatch_it_pair_3d.second, m_3d.rend<uchar>());
+
+    // const test
+    const cv::Mat m_1d_const(sizes_1d, CV_8U, data.data());
+
+    auto mismatch_it_pair_1d_const = std::mismatch(data.rbegin(), data.rend(), m_1d_const.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_1d_const.first, data.rend());  // expect no mismatch
+    EXPECT_EQ(mismatch_it_pair_1d_const.second, m_1d_const.rend<uchar>());
+
+    EXPECT_FALSE((std::is_assignable<decltype(m_1d_const.rend<uchar>()), uchar>::value)) << "Constness of const iterator violated.";
+    EXPECT_FALSE((std::is_assignable<decltype(m_1d_const.rbegin<uchar>()), uchar>::value)) << "Constness of const iterator violated.";
+}
+
 }} // namespace


### PR DESCRIPTION
Follow up of PR #19967 of opencv/opencv.
Iterators are working and tests are in place.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
